### PR TITLE
Show non-nullable status message for failed status responses

### DIFF
--- a/src/commonMain/kotlin/com/hedvig/authlib/AuthRepository.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/AuthRepository.kt
@@ -72,7 +72,7 @@ sealed interface AuthTokenResult {
 sealed interface LoginStatusResult {
     data class Exception(val message: String) : LoginStatusResult
     data class Failed(val message: String) : LoginStatusResult
-    data class Pending(val statusMessage: String?) : LoginStatusResult
+    data class Pending(val statusMessage: String) : LoginStatusResult
     data class Completed(val authorizationCode: AuthorizationCodeGrant) : LoginStatusResult
 }
 

--- a/src/commonMain/kotlin/com/hedvig/authlib/network/LoginStatusResponse.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/network/LoginStatusResponse.kt
@@ -10,8 +10,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LoginStatusResponse(
     val status: LoginStatus,
-    val statusText: String?,
-    val authorizationCode: String?
+    val statusText: String,
+    val authorizationCode: String?,
 ) {
     enum class LoginStatus {
         PENDING, FAILED, COMPLETED
@@ -30,7 +30,7 @@ suspend fun HttpResponse.toLoginStatusResult(): LoginStatusResult {
 
 private fun LoginStatusResponse.toLoginStatusResult() = when (status) {
     LoginStatusResponse.LoginStatus.PENDING -> LoginStatusResult.Pending(statusText)
-    LoginStatusResponse.LoginStatus.FAILED -> LoginStatusResult.Failed("Login status failed")
+    LoginStatusResponse.LoginStatus.FAILED -> LoginStatusResult.Failed(statusText)
     LoginStatusResponse.LoginStatus.COMPLETED -> {
         require(authorizationCode != null) {
             "Login status completed but did not receive authorization code"


### PR DESCRIPTION
Parse status message as non-nullable. Show for failed responses. 