### PR TITLE
Remove "migrateFromOldToken"

### DIFF
--- a/src/commonMain/kotlin/com/hedvig/authlib/AuthRepository.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/AuthRepository.kt
@@ -22,8 +22,6 @@ public interface AuthRepository {
     public suspend fun exchange(grant: Grant): AuthTokenResult
 
     public suspend fun revoke(token: String): RevokeResult
-
-    public suspend fun migrateOldToken(token: String): AuthTokenResult
 }
 
 @Suppress("unused")

--- a/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt
@@ -3,8 +3,6 @@ package com.hedvig.authlib
 import com.hedvig.authlib.internal.commonKtorConfiguration
 import com.hedvig.authlib.network.ExchangeAuthorizationCodeRequest
 import com.hedvig.authlib.network.ExchangeRefreshTokenRequest
-import com.hedvig.authlib.network.MigrateOldTokenRequest
-import com.hedvig.authlib.network.MigrateOldTokenResponse
 import com.hedvig.authlib.network.RevokeRequest
 import com.hedvig.authlib.network.SubmitOtpRequest
 import com.hedvig.authlib.network.buildStartLoginRequest
@@ -14,9 +12,7 @@ import com.hedvig.authlib.network.toLoginStatusResult
 import com.hedvig.authlib.network.toSubmitOtpResult
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
-import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.*
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody

--- a/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/NetworkAuthRepository.kt
@@ -196,23 +196,4 @@ public class NetworkAuthRepository(
             RevokeResult.Error("Error: ${e.message}")
         }
     }
-
-    override suspend fun migrateOldToken(token: String): AuthTokenResult {
-        return try {
-            val response = ktorClient.post("${environment.gatewayUrl}/migrate-auth-token") {
-                contentType(ContentType.Application.Json)
-                setBody(MigrateOldTokenRequest(token))
-            }
-
-            val responseBody = response.body<MigrateOldTokenResponse>()
-
-            return exchange(AuthorizationCodeGrant(responseBody.authorizationCode))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: IOException) {
-            AuthTokenResult.Error.IOError("IO Error with message: ${e.message ?: "unknown message"}")
-        } catch (e: Exception) {
-            AuthTokenResult.Error.UnknownError("Error: ${e.message}")
-        }
-    }
 }

--- a/src/commonMain/kotlin/com/hedvig/authlib/network/MigrateOldTokenRequest.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/network/MigrateOldTokenRequest.kt
@@ -1,8 +1,0 @@
-package com.hedvig.authlib.network
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-internal data class MigrateOldTokenRequest(
-    val token: String
-)

--- a/src/commonMain/kotlin/com/hedvig/authlib/network/MigrateOldTokenResponse.kt
+++ b/src/commonMain/kotlin/com/hedvig/authlib/network/MigrateOldTokenResponse.kt
@@ -1,8 +1,0 @@
-package com.hedvig.authlib.network
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-internal data class MigrateOldTokenResponse(
-    val authorizationCode: String
-)


### PR DESCRIPTION
Neither of the clients call this, and the backend does not seem to have it in the first place anymore
Can probably just remove it